### PR TITLE
Fix: search icon in search bar not vertically centre aligned

### DIFF
--- a/packages/renderer/src/components/ui/atomic-components/input/index.tsx
+++ b/packages/renderer/src/components/ui/atomic-components/input/index.tsx
@@ -25,7 +25,7 @@ export const Input = ({
   return (
     <div className={`relative w-full ${className}`}>
       {icon && (
-        <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+        <div className="absolute h-10 inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
           <span className="text-gray-500 sm:text-sm">{icon}</span>
         </div>
       )}


### PR DESCRIPTION
Fixes: #113 

<img width="386" alt="image" src="https://user-images.githubusercontent.com/41536903/193424386-bacd9955-874c-4346-9540-6b02fbd9b4cb.png">
