### PR TITLE
feat(devcontainer): enable dev environments in GH Codespaces and VS Code remote containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,18 @@
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
+ARG VARIANT=16-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get -y upgrade \
+  && apt-get -y install --no-install-recommends git nano openssl libnss3-dev chromium zsh \
+  && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /root/.gnupg /tmp/library-scripts
+
+RUN chsh -s $(which zsh) root \
+  && chsh -s $(which zsh) node
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node modules
+# RUN su node -c "npm install -g <your-package-list-here>"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,8 +11,8 @@ RUN chsh -s $(which zsh) root \
   && chsh -s $(which zsh) node
 
 # Clone a sample repos with svg icons in it
-RUN cd /home && git clone https://github.com/Remix-Design/RemixIcon.git
-RUN cd /home && git clone https://github.com/tailwindlabs/heroicons.git
+RUN cd /home/node && git clone https://github.com/Remix-Design/RemixIcon.git
+RUN cd /home/node && git clone https://github.com/tailwindlabs/heroicons.git
 
 EXPOSE 3000
 EXPOSE 5901

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,8 +10,9 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 RUN chsh -s $(which zsh) root \
   && chsh -s $(which zsh) node
 
-# Clone a sample repo with svg icons in it
-RUN git clone https://github.com/Remix-Design/RemixIcon.git
+# Clone a sample repos with svg icons in it
+RUN cd /home && git clone https://github.com/Remix-Design/RemixIcon.git
+RUN cd /home && git clone https://github.com/tailwindlabs/heroicons.git
 
 EXPOSE 3000
 EXPOSE 5901

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,6 +10,9 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 RUN chsh -s $(which zsh) root \
   && chsh -s $(which zsh) node
 
+# Clone a sample repo with svg icons in it
+RUN git clone https://github.com/Remix-Design/RemixIcon.git
+
 EXPOSE 3000
 EXPOSE 5901
 EXPOSE 6080

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,6 +10,10 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 RUN chsh -s $(which zsh) root \
   && chsh -s $(which zsh) node
 
+EXPOSE 3000
+EXPOSE 5901
+EXPOSE 6080
+
 # [Optional] Uncomment if you want to install an additional version of node using nvm
 # ARG EXTRA_NODE_VERSION=10
 # RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "iconshelf",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "iconshelf",
+  "workspaceFolder": "/workspace",
+  "settings": {},
+  "extensions": [
+    "bradlc.vscode-tailwindcss",
+    "dbaeumer.vscode-eslint",
+    "EditorConfig.EditorConfig",
+    "esbenp.prettier-vscode"
+  ],
+  "postCreateCommand": "npm ci",
+  "remoteUser": "node",
+  "features": {
+    "ghcr.io/devcontainers/features/desktop-lite:1": {
+      "version": "latest",
+      "webPort": 6080,
+      "vncPort": 5901
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
     "EditorConfig.EditorConfig",
     "esbenp.prettier-vscode"
   ],
-  "forwardPorts": ["3000:3000", "5901:5901", "6080:6080"],
+  "forwardPorts": [3000, 5901, 6080],
   "portsAttributes": {
     "3000": {
       "label": "Dev Server",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
     },
     "6080": {
       "label": "NoVNC Web",
-      "onAutoForward": "openPreview"
+      "onAutoForward": "openBrowserOnce"
     }
   },
   "features": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,8 @@
   "dockerComposeFile": "docker-compose.yml",
   "service": "iconshelf",
   "workspaceFolder": "/workspace",
+  "postCreateCommand": "npm ci",
+  "remoteUser": "node",
   "settings": {},
   "extensions": [
     "bradlc.vscode-tailwindcss",
@@ -11,8 +13,20 @@
     "esbenp.prettier-vscode"
   ],
   "forwardPorts": ["3000:3000", "5901:5901", "6080:6080"],
-  "postCreateCommand": "npm ci",
-  "remoteUser": "node",
+  "portsAttributes": {
+    "3000": {
+      "label": "Dev Server",
+      "onAutoForward": "notify"
+    },
+    "5091": {
+      "label": "NoVNC Internal",
+      "onAutoForward": "silent"
+    },
+    "6080": {
+      "label": "NoVNC Web",
+      "onAutoForward": "openPreview"
+    }
+  },
   "features": {
     "ghcr.io/devcontainers/features/desktop-lite:1": {
       "version": "latest",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,7 @@
     "EditorConfig.EditorConfig",
     "esbenp.prettier-vscode"
   ],
+  "forwardPorts": ["3000:3000", "5901:5901", "6080:6080"],
   "postCreateCommand": "npm ci",
   "remoteUser": "node",
   "features": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "dockerComposeFile": "docker-compose.yml",
   "service": "iconshelf",
   "workspaceFolder": "/workspace",
-  "postCreateCommand": "npm ci",
+  "postCreateCommand": "mkdir -p node_modules && sudo chown -R node:node node_modules && npm ci",
   "remoteUser": "node",
   "settings": {},
   "extensions": [

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "2.1"
+
+services:
+  iconshelf:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        VARIANT: 16-bullseye
+
+    security_opt:
+      - seccomp:unconfined
+
+    environment:
+      - PUID=1000
+      - PGID=1000
+
+    working_dir: /workspace
+
+    volumes:
+      - ..:/workspace:cached
+      - iconshelf_node_modules:/workspace/node_modules
+
+    ports:
+      - 3000:3000
+      - 6080:6080
+      - 5901:5901
+
+    devices:
+      - /dev/dri:/dev/dri # provide GL access
+
+    shm_size: "1gb" # provide min required memory for electron not to crash
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: /bin/sh -c "while sleep 1000; do :; done"
+
+    user: node
+
+volumes:
+  iconshelf_node_modules:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -26,9 +26,6 @@ services:
       - 6080:6080
       - 5901:5901
 
-    devices:
-      - /dev/dri:/dev/dri # provide GL access
-
     shm_size: "1gb" # provide min required memory for electron not to crash
 
     # Overrides default command so things don't shut down after the process ends.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -21,11 +21,6 @@ services:
       - ..:/workspace:cached
       - iconshelf_node_modules:/workspace/node_modules
 
-    ports:
-      - 3000:3000
-      - 6080:6080
-      - 5901:5901
-
     shm_size: "1gb" # provide min required memory for electron not to crash
 
     # Overrides default command so things don't shut down after the process ends.

--- a/contributing.md
+++ b/contributing.md
@@ -17,7 +17,7 @@ _It can't be understated how frustrating and draining it can be to maintainers t
 
 ## Repo Setup
 
-> *Note* that this repository is compatible with GitHub Codespaces as well as VS Code Remote Containers. Opening your cloned project with either of these options will perform these dev setup steps for you automatically!
+> _Note_ that this repository is compatible with GitHub Codespaces as well as VS Code Remote Containers. Opening your cloned project with either of these options will perform these dev setup steps for you automatically! [demo](https://vimeo.com/757666222)
 
 The package manager used to install and link dependencies must be npm v7 or later.
 

--- a/contributing.md
+++ b/contributing.md
@@ -17,6 +17,8 @@ _It can't be understated how frustrating and draining it can be to maintainers t
 
 ## Repo Setup
 
+> *Note* that this repository is compatible with GitHub Codespaces as well as VS Code Remote Containers. Opening your cloned project with either of these options will perform these dev setup steps for you automatically!
+
 The package manager used to install and link dependencies must be npm v7 or later.
 
 > Make sure you have Node version 16.x installed!


### PR DESCRIPTION
This project is marked as open to contribution for `Hacktoberfest`, and as such I figured it would be desirable for contributors to have a simplified means of getting up and running with the developer setup. With the addition of the `devcontainer` configuration, this project is now compatible with `GitHub Codespaces` as well as `VS Code Remote Containers`. Contributors who use one of these options now get all of the dev setup steps completed for them, and you get peace of mind that contributions will come from setups with the correct usage of eslint, prettier, etc.

**EDIT:**

## Demo

https://vimeo.com/757666222