### PR TITLE
Add sort by name for collection

### DIFF
--- a/packages/renderer/assets/icons/arrow-down.svg
+++ b/packages/renderer/assets/icons/arrow-down.svg
@@ -1,0 +1,3 @@
+<svg width='24' height='24' xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 13.5L12 21m0 0l-7.5-7.5M12 21V3" />
+</svg>

--- a/packages/renderer/assets/icons/arrows-up-down.svg
+++ b/packages/renderer/assets/icons/arrows-up-down.svg
@@ -1,0 +1,3 @@
+<svg width='24' height='24' xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M3 7.5L7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5" />
+</svg>

--- a/packages/renderer/src/components/modules/IconsHome/LeftIconsCollectionsNav/ListItemWrapper/ListItem/OptionsOverlay.tsx
+++ b/packages/renderer/src/components/modules/IconsHome/LeftIconsCollectionsNav/ListItemWrapper/ListItem/OptionsOverlay.tsx
@@ -8,13 +8,25 @@ import { ReactComponent as CursorClickIcon } from '/assets/icons/cursor-click-sm
 import { platformBasedText } from '/@/utils/platformText';
 import { ReactComponent as CollectionIcon } from '/assets/icons/collection-16.svg';
 import { uuidv4 } from '/@/utils/uuid';
+import { SortItem } from './SortItem';
 
-export const OptionsOverlay: FC<React.PropsWithChildren<{
-  collection?: Collection;
-  onDeleteClick?: () => void;
-  editCollection?: (c?: Collection) => void;
-  onCustomizeActionsClick?: (c?: Collection) => void;
-}>> = ({ collection, editCollection, onDeleteClick, onCustomizeActionsClick }) => {
+export const OptionsOverlay: FC<
+  React.PropsWithChildren<{
+    collection?: Collection;
+    onDeleteClick?: () => void;
+    editCollection?: (c?: Collection) => void;
+    onCustomizeActionsClick?: (c?: Collection) => void;
+    onSortClick: () => void;
+    isActive: boolean;
+  }>
+> = ({
+  collection,
+  editCollection,
+  onDeleteClick,
+  onSortClick,
+  onCustomizeActionsClick,
+  isActive,
+}) => {
   const openCollectionFolderInFinder = () => {
     window.electron.ipcRenderer.send('open-collection-folder', collection?.folderSrc);
   };
@@ -52,6 +64,12 @@ export const OptionsOverlay: FC<React.PropsWithChildren<{
         <CursorClickIcon className="mr-2" />
         <div>Customize actions</div>
       </Dropdown.Item>
+
+      {isActive && (
+        <Dropdown.Item onClick={onSortClick}>
+          <SortItem />
+        </Dropdown.Item>
+      )}
 
       <Dropdown.Item onClick={createSubCollection}>
         <CollectionIcon className="mr-2" />

--- a/packages/renderer/src/components/modules/IconsHome/LeftIconsCollectionsNav/ListItemWrapper/ListItem/SortItem.tsx
+++ b/packages/renderer/src/components/modules/IconsHome/LeftIconsCollectionsNav/ListItemWrapper/ListItem/SortItem.tsx
@@ -5,7 +5,6 @@ import { ReactComponent as ArrowsUpDown } from '/assets/icons/arrows-up-down.svg
 export const SortItem = () => {
   const [searchParams] = useSearchParams();
   const isSortedDesc = searchParams.get('sortByNameDesc');
-  console.log(searchParams.toString());
 
   if (isSortedDesc === null)
     return (

--- a/packages/renderer/src/components/modules/IconsHome/LeftIconsCollectionsNav/ListItemWrapper/ListItem/SortItem.tsx
+++ b/packages/renderer/src/components/modules/IconsHome/LeftIconsCollectionsNav/ListItemWrapper/ListItem/SortItem.tsx
@@ -1,0 +1,29 @@
+import { useSearchParams } from 'react-router-dom';
+import { ReactComponent as ArrowDown } from '/assets/icons/arrow-down.svg';
+import { ReactComponent as ArrowsUpDown } from '/assets/icons/arrows-up-down.svg';
+
+export const SortItem = () => {
+  const [searchParams] = useSearchParams();
+  const isSortedDesc = searchParams.get('sortByNameDesc');
+  console.log(searchParams.toString());
+
+  if (isSortedDesc === null)
+    return (
+      <>
+        <ArrowDown className="w-4 h-4 mr-2 rotate-180" />
+        <span>Sort by name ascending</span>
+      </>
+    );
+
+  return isSortedDesc === 'true' ? (
+    <>
+      <ArrowsUpDown className="w-4 h-4 mr-2" />
+      <span>Reset sorting</span>
+    </>
+  ) : (
+    <>
+      <ArrowDown className="w-4 h-4 mr-2" />
+      <span>Sort by name descending</span>
+    </>
+  );
+};

--- a/packages/renderer/src/components/modules/IconsHome/LeftIconsCollectionsNav/ListItemWrapper/ListItem/index.tsx
+++ b/packages/renderer/src/components/modules/IconsHome/LeftIconsCollectionsNav/ListItemWrapper/ListItem/index.tsx
@@ -24,6 +24,7 @@ interface Props {
   onShowChildCollectionsToggle?: (v: boolean) => void;
   editCollection?: (v?: Collection) => void;
   onCustomizeActionsClick?: (v?: Collection) => void;
+  onSortClick: () => void;
 }
 
 export const ListItem: FC<React.PropsWithChildren<Props>> = ({
@@ -38,6 +39,7 @@ export const ListItem: FC<React.PropsWithChildren<Props>> = ({
   onShowChildCollectionsToggle,
   editCollection,
   onCustomizeActionsClick,
+  onSortClick,
 }) => {
   const queryClent = useQueryClient();
   const navigate = useNavigate();
@@ -100,6 +102,8 @@ export const ListItem: FC<React.PropsWithChildren<Props>> = ({
                   editCollection={editCollection}
                   onCustomizeActionsClick={onCustomizeActionsClick}
                   onDeleteClick={() => setShowDeleteConfirm(true)}
+                  onSortClick={onSortClick}
+                  isActive={isActive}
                 />
               }
               onMenuButtonClick={(opened) => setDropdownIsVisible(opened)}

--- a/packages/renderer/src/components/modules/IconsHome/LeftIconsCollectionsNav/ListItemWrapper/index.tsx
+++ b/packages/renderer/src/components/modules/IconsHome/LeftIconsCollectionsNav/ListItemWrapper/index.tsx
@@ -11,6 +11,7 @@ interface Props {
   marginLeft?: number;
   editCollection?: (v?: Collection) => void;
   onCustomizeActionsClick?: (v?: Collection) => void;
+  onSortClick: () => void;
 }
 export const ListItemWrapper: FC<React.PropsWithChildren<Props>> = ({
   collection,
@@ -19,6 +20,7 @@ export const ListItemWrapper: FC<React.PropsWithChildren<Props>> = ({
   marginLeft = 0,
   editCollection,
   onCustomizeActionsClick,
+  onSortClick,
 }) => {
   const [showChildCollections, setShowChildCollections] = useState(
     !!collection?.childCollectionIds?.length
@@ -40,6 +42,7 @@ export const ListItemWrapper: FC<React.PropsWithChildren<Props>> = ({
         onCustomizeActionsClick={onCustomizeActionsClick}
         showChildCollections={showChildCollections}
         onShowChildCollectionsToggle={onShowChildCollectionsToggle}
+        onSortClick={onSortClick}
       />
 
       {showChildCollections &&
@@ -56,6 +59,7 @@ export const ListItemWrapper: FC<React.PropsWithChildren<Props>> = ({
                 selectedCollectionId={selectedCollectionId}
                 editCollection={editCollection}
                 onCustomizeActionsClick={onCustomizeActionsClick}
+                onSortClick={onSortClick}
               />
             )
           );

--- a/packages/renderer/src/components/modules/IconsHome/LeftIconsCollectionsNav/index.tsx
+++ b/packages/renderer/src/components/modules/IconsHome/LeftIconsCollectionsNav/index.tsx
@@ -1,5 +1,5 @@
-import type { FC } from 'react';
-import { useState, Fragment } from 'react';
+import type { FC, PropsWithChildren } from 'react';
+import { useState } from 'react';
 import { ReactComponent as PlusIcon } from '/assets/icons/plus.svg';
 import { ReactComponent as ViewGridIcon } from '/assets/icons/view-grid.svg';
 import { Button, TitleBarDrag } from '/@/components/ui/atomic-components';
@@ -14,7 +14,10 @@ import { CustomizeActionsModal } from './CustomizeActionsModal/index';
 import { ListItemWrapper } from './ListItemWrapper';
 import { Resizable } from 're-resizable';
 
-export const LeftIconsCollectionsNav: FC<React.PropsWithChildren<unknown>> = () => {
+interface Props extends PropsWithChildren {
+  onSortClick: () => void;
+}
+export const LeftIconsCollectionsNav: FC<Props> = ({ onSortClick }) => {
   const { collectionId: selectedCollectionId } = useParams();
 
   const { data: collections } = useQuery(['collections-list'], () => CollectionsApi.findAll());
@@ -36,16 +39,25 @@ export const LeftIconsCollectionsNav: FC<React.PropsWithChildren<unknown>> = () 
 
   return (
     <>
-    <Resizable
-    size={{ width: '16rem', height: 'auto' }}
-    enable={{ top:false, right:true, bottom:false, left:false, topRight:false, bottomRight:false, bottomLeft:false, topLeft:false }}
-    minWidth="256px"
-    maxWidth="320px"
-    className="relative h-full w-64 min-w-max flex-shrink-0 bg-gray-200 dark:bg-black2"
->
+      <Resizable
+        size={{ width: '16rem', height: 'auto' }}
+        enable={{
+          top: false,
+          right: true,
+          bottom: false,
+          left: false,
+          topRight: false,
+          bottomRight: false,
+          bottomLeft: false,
+          topLeft: false,
+        }}
+        minWidth="256px"
+        maxWidth="320px"
+        className="relative flex-shrink-0 w-64 h-full bg-gray-200 min-w-max dark:bg-black2"
+      >
         <TitleBarDrag className="absolute inset-0 h-8" />
 
-        <div className="mx-4 mt-5 flex justify-end">
+        <div className="flex justify-end mx-4 mt-5">
           <Tooltip placement="left" overlay={<span>Create collection</span>}>
             <Button
               icon={<PlusIcon />}
@@ -56,7 +68,7 @@ export const LeftIconsCollectionsNav: FC<React.PropsWithChildren<unknown>> = () 
           </Tooltip>
         </div>
 
-        <div className="mt-5 flex flex-col gap-2">
+        <div className="flex flex-col gap-2 mt-5">
           <ListItem
             name="All icons"
             id="all-icons"
@@ -65,13 +77,14 @@ export const LeftIconsCollectionsNav: FC<React.PropsWithChildren<unknown>> = () 
             icon={<ViewGridIcon />}
             isActive={selectedCollectionId === 'all-icons'}
             hideOptions
+            onSortClick={onSortClick}
           />
         </div>
 
-        <div className="mt-4 h-full">
+        <div className="h-full mt-4">
           <div className="ml-4 text-base">Collections</div>
           <div
-            className="mt-2 flex flex-col gap-2 overflow-auto pb-24"
+            className="flex flex-col gap-2 pb-24 mt-2 overflow-auto"
             style={{ height: 'calc(100% - 120px)' }}
           >
             {collections
@@ -84,12 +97,12 @@ export const LeftIconsCollectionsNav: FC<React.PropsWithChildren<unknown>> = () 
                   selectedCollectionId={selectedCollectionId}
                   editCollection={editCollection}
                   onCustomizeActionsClick={onCustomizeActionsClick}
+                  onSortClick={onSortClick}
                 />
               ))}
           </div>
         </div>
-    </Resizable>
-     
+      </Resizable>
 
       <CreateEditCollectionModal
         show={showCollectionModal}


### PR DESCRIPTION
This fixes #103 

Added sort by name for collections. You can sort only currently selected collection. Sorting is reset when you change collections. 

Here is a video walkthrough:

https://user-images.githubusercontent.com/15055321/198985061-e26117e0-9fef-4d49-ac82-1593734deb2b.mov


P.S. sorry for committed formatting changes :(