### PR TITLE
feat: move collections plus icon

### DIFF
--- a/packages/renderer/src/components/modules/IconsHome/LeftIconsCollectionsNav/index.tsx
+++ b/packages/renderer/src/components/modules/IconsHome/LeftIconsCollectionsNav/index.tsx
@@ -55,9 +55,9 @@ export const LeftIconsCollectionsNav: FC<Props> = ({ onSortClick }) => {
         maxWidth="320px"
         className="relative flex-shrink-0 w-64 h-full bg-gray-200 min-w-max dark:bg-black2"
       >
-        <TitleBarDrag className="absolute inset-0 h-8" />
+        <TitleBarDrag className="absolute inset-0 h-4" />
 
-        <div className="flex flex-col gap-2 mt-8" /*has to be mt-8, else drop bar prevents from clicking, was visible on [+] button too */>
+        <div className="flex flex-col gap-2 mt-4">
           <ListItem
             name="All icons"
             id="all-icons"
@@ -71,7 +71,7 @@ export const LeftIconsCollectionsNav: FC<Props> = ({ onSortClick }) => {
         </div>
 
         <div className="h-full mt-4">
-          <div className="mx-4 text-base flex justify-between items-center">
+          <div className="ml-4 mr-3 text-base flex justify-between items-center">
             <span className="h-full">Collections</span>
             <Tooltip placement="left" overlay={<span>Create collection</span>}>
               <Button

--- a/packages/renderer/src/components/modules/IconsHome/LeftIconsCollectionsNav/index.tsx
+++ b/packages/renderer/src/components/modules/IconsHome/LeftIconsCollectionsNav/index.tsx
@@ -57,18 +57,7 @@ export const LeftIconsCollectionsNav: FC<Props> = ({ onSortClick }) => {
       >
         <TitleBarDrag className="absolute inset-0 h-8" />
 
-        <div className="flex justify-end mx-4 mt-5">
-          <Tooltip placement="left" overlay={<span>Create collection</span>}>
-            <Button
-              icon={<PlusIcon />}
-              type="text"
-              id="create-collection-btn"
-              onClick={() => editCollection()}
-            />
-          </Tooltip>
-        </div>
-
-        <div className="flex flex-col gap-2 mt-5">
+        <div className="flex flex-col gap-2 mt-8" /*has to be mt-8, else drop bar prevents from clicking, was visible on [+] button too */>
           <ListItem
             name="All icons"
             id="all-icons"
@@ -82,7 +71,17 @@ export const LeftIconsCollectionsNav: FC<Props> = ({ onSortClick }) => {
         </div>
 
         <div className="h-full mt-4">
-          <div className="ml-4 text-base">Collections</div>
+          <div className="mx-4 text-base flex justify-between items-center">
+            <span className="h-full">Collections</span>
+            <Tooltip placement="left" overlay={<span>Create collection</span>}>
+              <Button
+                icon={<PlusIcon />}
+                type="text"
+                id="create-collection-btn"
+                onClick={() => editCollection()}
+              />
+            </Tooltip>
+          </div>
           <div
             className="flex flex-col gap-2 pb-24 mt-2 overflow-auto"
             style={{ height: 'calc(100% - 120px)' }}

--- a/packages/renderer/src/components/modules/IconsHome/LeftIconsCollectionsNav/index.tsx
+++ b/packages/renderer/src/components/modules/IconsHome/LeftIconsCollectionsNav/index.tsx
@@ -70,8 +70,8 @@ export const LeftIconsCollectionsNav: FC<Props> = ({ onSortClick }) => {
           />
         </div>
 
-        <div className="h-full mt-4">
-          <div className="ml-4 mr-3 text-base flex justify-between items-center">
+        <div className="h-full mt-2">
+          <div className="ml-4 mr-3 text-lg flex justify-between items-center">
             <span className="h-full">Collections</span>
             <Tooltip placement="left" overlay={<span>Create collection</span>}>
               <Button


### PR DESCRIPTION
Moves the **[+]** icon next to the `Collections` section, as requested in #148.
The **[+]** icon is aligned over **[…]** (horizontal dots) icons of user collections.
At the same time, the font size of `Collections` was changed to scale better with the icon in the same row.

Some margins were changed to look visually more appealing.
The size of the `All Icons` top margin is now smaller while making sure to keep the section clickable, as there is an `absolute` positioned `<TitleDragBar>` that could cover the `All Icons` (like it was partly for the **[+]** icon before).

![Image of the `LeftIconsCollectionsNav` with the new layout, the + button next to the collection's title, aligned with the horizontal dots of collections](https://user-images.githubusercontent.com/44443899/227237235-4cbafc68-8ac0-41db-ac0d-b1250d219d37.png)

Please explain the use of the `<TitleDragBar>` and feel free to change the margin heights and font sizes back. Thanks
