### PR TITLE
feat: use tanstack virtual

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,8 @@
         "@dnd-kit/sortable": "^7.0.1",
         "@fontsource/dm-sans": "^4.5.9",
         "@headlessui/react": "^1.7.3",
-        "@mierak/react-virtualized-grid": "^0.0.5-ALPHA",
         "@tanstack/react-query": "^4.10.1",
+        "@tanstack/react-virtual": "^3.0.0-beta.54",
         "chokidar": "^3.5.3",
         "dexie": "^3.2.2",
         "electron-log": "^4.4.8",
@@ -1198,15 +1198,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@mierak/react-virtualized-grid": {
-      "version": "0.0.5-ALPHA",
-      "resolved": "https://registry.npmjs.org/@mierak/react-virtualized-grid/-/react-virtualized-grid-0.0.5-ALPHA.tgz",
-      "integrity": "sha512-K7TVmRooNKsfN/69dUPJzkKRFE9e9ZUrQclxxHn0Tok5EcDIhz95CK5YcNbWdNjlprf0WGFGJ9o6cZFZ7nK/6g==",
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1588,6 +1579,30 @@
         "@tanstack/react-query": "4.10.1",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.54.tgz",
+      "integrity": "sha512-D1mDMf4UPbrtHRZZriCly5bXTBMhylslm4dhcHqTtDJ6brQcgGmk8YD9JdWBGWfGSWPKoh2x1H3e7eh+hgPXtQ==",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.0.0-beta.54"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.54.tgz",
+      "integrity": "sha512-jtkwqdP2rY2iCCDVAFuaNBH3fiEi29aTn2RhtIoky8DTTiCdc48plpHHreLwmv1PICJ4AJUUESaq3xa8fZH8+g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -11993,12 +12008,6 @@
         }
       }
     },
-    "@mierak/react-virtualized-grid": {
-      "version": "0.0.5-ALPHA",
-      "resolved": "https://registry.npmjs.org/@mierak/react-virtualized-grid/-/react-virtualized-grid-0.0.5-ALPHA.tgz",
-      "integrity": "sha512-K7TVmRooNKsfN/69dUPJzkKRFE9e9ZUrQclxxHn0Tok5EcDIhz95CK5YcNbWdNjlprf0WGFGJ9o6cZFZ7nK/6g==",
-      "requires": {}
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -12209,6 +12218,19 @@
         "superjson": "^1.10.0",
         "use-sync-external-store": "^1.2.0"
       }
+    },
+    "@tanstack/react-virtual": {
+      "version": "3.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.54.tgz",
+      "integrity": "sha512-D1mDMf4UPbrtHRZZriCly5bXTBMhylslm4dhcHqTtDJ6brQcgGmk8YD9JdWBGWfGSWPKoh2x1H3e7eh+hgPXtQ==",
+      "requires": {
+        "@tanstack/virtual-core": "3.0.0-beta.54"
+      }
+    },
+    "@tanstack/virtual-core": {
+      "version": "3.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.54.tgz",
+      "integrity": "sha512-jtkwqdP2rY2iCCDVAFuaNBH3fiEi29aTn2RhtIoky8DTTiCdc48plpHHreLwmv1PICJ4AJUUESaq3xa8fZH8+g=="
     },
     "@tootallnate/once": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "postinstall": "cross-env ELECTRON_RUN_AS_NODE=1 electron scripts/update-electron-vendors.mjs"
   },
   "devDependencies": {
+    "@tanstack/react-query-devtools": "^4.10.1",
     "@types/electron-devtools-installer": "2.2.2",
     "@types/htmltojsx": "^0.0.30",
     "@types/lodash": "^4.14.186",
@@ -36,6 +37,7 @@
     "@types/universal-analytics": "^0.4.5",
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "5.39.0",
+    "@typescript-eslint/parser": "^5.39.0",
     "@vitejs/plugin-react": "^2.1.0",
     "autoprefixer": "^10.4.12",
     "clean-terminal-webpack-plugin": "^3.0.0",
@@ -59,9 +61,7 @@
     "typescript": "4.8.4",
     "vite": "^3.1.4",
     "vite-plugin-svgr": "^2.2.1",
-    "xvfb-maybe": "^0.2.1",
-    "@typescript-eslint/parser": "^5.39.0",
-    "@tanstack/react-query-devtools": "^4.10.1"
+    "xvfb-maybe": "^0.2.1"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^0.19.14",
@@ -80,8 +80,9 @@
     "@dnd-kit/sortable": "^7.0.1",
     "@fontsource/dm-sans": "^4.5.9",
     "@headlessui/react": "^1.7.3",
-    "@mierak/react-virtualized-grid": "^0.0.5-ALPHA",
     "@tanstack/react-query": "^4.10.1",
+    "@tanstack/react-virtual": "^3.0.0-beta.54",
+    "chokidar": "^3.5.3",
     "dexie": "^3.2.2",
     "electron-log": "^4.4.8",
     "electron-store": "^8.1.0",
@@ -100,8 +101,7 @@
     "react-router-dom": "^6.4.1",
     "svgo": "^2.8.0",
     "universal-analytics": "^0.5.3",
-    "uuid": "^9.0.0",
-    "chokidar": "^3.5.3"
+    "uuid": "^9.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/renderer/src/components/modules/IconsHome/IconCardsSection/index.tsx
+++ b/packages/renderer/src/components/modules/IconsHome/IconCardsSection/index.tsx
@@ -6,7 +6,7 @@ import { HotKeys } from 'react-hotkeys';
 import { IconCard } from './IconCard';
 import { EmptyPlaceholder } from './EmptyPlaceholder';
 import { IconContextMenu } from './IconContextMenu';
-import { VirtualizedGrid } from '@mierak/react-virtualized-grid';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { useHotKeyConfig } from './hooks';
 
 interface Props {
@@ -34,6 +34,13 @@ export const IconCardsSection: FC<React.PropsWithChildren<Props>> = ({
     setTimeout(() => setRefreshGrid(false), 1);
   }, [icons]);
 
+  const gridVirtualizer = useVirtualizer({
+    count: icons?.length ?? 0,
+    getScrollElement: () => wrapperDivRef.current,
+    estimateSize: () => 128,
+    scrollingDelay: 100,
+  });
+
   if (refreshGrid) {
     return <></>;
   }
@@ -46,17 +53,8 @@ export const IconCardsSection: FC<React.PropsWithChildren<Props>> = ({
     <>
       <div className="relative h-full w-full overflow-hidden" ref={wrapperDivRef}>
         <HotKeys keyMap={keyMap} handlers={handlers} className="h-full outline-none">
-          <VirtualizedGrid
-            rowHeight={128}
-            cellWidth={128}
-            gridGap={12}
-            itemCount={icons.length}
-            gridHeight={'min(min-content, 100%'}
-            className={'virtualized-icons-grid-container px-4 pb-16'}
-            debounceDelay={100}
-            prerenderScreens={5}
-          >
-            {(index) => {
+          <div className="virtualized-icons-grid-container grid grid-cols-[repeat(auto-fill,minmax(128px,1fr))] gap-3 px-4 pb-16">
+            {gridVirtualizer.getVirtualItems().map((_, index) => {
               const icon = icons[index];
 
               return (
@@ -68,8 +66,8 @@ export const IconCardsSection: FC<React.PropsWithChildren<Props>> = ({
                   color={color}
                 />
               );
-            }}
-          </VirtualizedGrid>
+            })}
+          </div>
         </HotKeys>
       </div>
 

--- a/packages/renderer/src/components/modules/IconsHome/IconCardsSection/index.tsx
+++ b/packages/renderer/src/components/modules/IconsHome/IconCardsSection/index.tsx
@@ -39,6 +39,7 @@ export const IconCardsSection: FC<React.PropsWithChildren<Props>> = ({
     getScrollElement: () => wrapperDivRef.current,
     estimateSize: () => 128,
     scrollingDelay: 100,
+    overscan: 24 * 5,
   });
 
   if (refreshGrid) {


### PR DESCRIPTION
This PR installs `@tanstack/react-virtual@beta` and removes `@mierak/react-virtualized-grid` package. (The package manager sorted the rest of the packages automatically)

## Replacing `<VirtualizedGrid>`
The virtualized items use the `useVirtualizer` function, trying to replace the `VirtualizedGrid>` component.
`useVirtualizer` must be called before any return statements because of React hooks needing to be always called in the same order.
As the `<VirtualizedGrid>` component isn't used anymore, a new `<div>` wrapper is needed to ensure the same behavior.

## Styling
For keeping the styles the same, the class `grid grid-cols-[repeat(auto-fill,minmax(128px,1fr))]` has the most influence. It is a customized tailwind value for grid-template-columns.

The `minmax` function defines, that grid children are 128px wide minimum and max 1 fraction of the grid.

The repeat ensures that as many items as possible fit into one row.
The `auto-fill` makes that when items are missing to fill the row, that not the full space is used by one item, by 'faking the presence' of more children and keeping the width of items around 128px.

The height of items is handled by the `<IconCard>` component and does not have to be set.

## Pre-rendering
The `overscan` value = pre-rendered items is set to `5*24` any tries to prepare around 5 screens top and bottom from the view. This is a rough approximation and probably isn't correct for most screens.

Feel free to replace this value.

<details>
<summary>Before / After</summary>

This is how it looked on my system, so I don't know if the resizing problems were just for me.

Before: @mierak/react-virtualized-grid

[before](https://user-images.githubusercontent.com/44443899/229636918-c7adae7a-1e0e-46d4-a22a-cdd13d8dd84c.webm)

---

After: @tanstack/react-virtual@beta

[after](https://user-images.githubusercontent.com/44443899/229636922-172046e0-b068-433c-85e4-87d7b2c9dfe2.webm)
</details>

## Linked issue
#99 